### PR TITLE
feat(identity-service): domain layer - User, Account, events, and output ports

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(gh project:*)"
-    ]
-  }
-}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh project:*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ Thumbs.db
 # Logs
 *.log
 logs/
+
+# Claude Code
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,8 @@ Ciphernance emulates the core of a banking system focused on transactions, autho
 ## Services
 
 - **api-gateway** — Entry point. JWT validation, ABAC first layer (PEP), rate limiting, routing. Spring Cloud Gateway.
-- **identity-service** — Source of truth for identities, accounts, and authorization policies. Spring Authorization Server. Manages PAP (YAML policies), PIP (user/account attributes). Compiles YAML policies and distributes via Kafka.
-- **account-service** — Account state and balance management. Validates balance, reserves funds during Saga, finalizes debit/credit after confirmation. Blocks accounts on fraud detection.
+- **identity-service** — Source of truth for identities, accounts, and authorization policies. Spring Authorization Server. Manages PAP (YAML policies), PIP (user/account attributes). Compiles YAML policies and distributes via Kafka. Owns User and Account domain entities.
+- **wallet-service** — Wallet and balance management. Owns Wallet and Balance domain entities. Creates Wallet upon AccountCreatedEvent from identity-service. Validates balance, reserves funds during Saga, finalizes debit/credit after confirmation. Blocks wallets on fraud detection.
 - **transaction-service** — Orchestrates the transfer Saga. ABAC authorization (ownership validation). Event Sourcing for transaction state. Choreography-based Saga coordinator.
 - **fraud-service** — Pattern analysis. Redis for fast rules. Neo4J for relationship graphs (transfer cycles, shared devices). Publishes CLEARED or SUSPECTED verdict.
 - **audit-service** — Immutable event history. Consumes authorization audit events and business events from all services. Never affects main flow latency.
@@ -73,11 +73,11 @@ Ciphernance emulates the core of a banking system focused on transactions, autho
 1. Client → API Gateway (JWT validated)
 2. API Gateway → Transaction Service
 3. Transaction Service: ABAC check (ownership + permission) → publishes TransactionInitiatedEvent → state: PENDING
-4. Account Service: validates balance + account state → reserves funds → publishes AccountsValidatedEvent or AccountValidationFailedEvent
+4. Wallet Service: validates balance + wallet state → reserves funds → publishes AccountsValidatedEvent or AccountValidationFailedEvent
 5. Transaction Service: publishes TransactionApprovedForAnalysisEvent
 6. Fraud Service: analyzes patterns → publishes TransactionClearedEvent or FraudSuspectedEvent
-7a. CLEARED → Transaction Service publishes TransactionCompletedEvent → Account Service finalizes debit/credit
-7b. SUSPECTED → Transaction Service publishes TransactionReversalEvent → Account Service releases reserved funds + blocks accounts → Identity Service publishes AccessRevokedEvent
+7a. CLEARED → Transaction Service publishes TransactionCompletedEvent → Wallet Service finalizes debit/credit
+7b. SUSPECTED → Transaction Service publishes TransactionReversalEvent → Wallet Service releases reserved funds + blocks wallets → Identity Service publishes AccessRevokedEvent
 
 ## ADRs
 
@@ -89,6 +89,8 @@ See /docs/adr/ for all Architectural Decision Records.
 - ADR-004: Event Sourcing in Transaction Service
 - ADR-005: Two-level cache L1 Caffeine + L2 Redis
 - ADR-006: No decision-level cache in financial systems
+- ADR-007: UUID v7 as Primary Key Strategy
+- ADR-008: Domain Model — User, Account, Wallet, Balance
 
 ## Git Workflow
 
@@ -111,3 +113,21 @@ See /docs/adr/ for all Architectural Decision Records.
 - Each service has its own PostgreSQL schema
 - Policy Agent is embedded in each service JAR — not a separate service
 - Out of scope for MVP: deposits, withdrawals, credit, investments, card, real Banco Central integration, Kubernetes, frontend
+
+## Implementation Notes
+
+### identity-service domain layer
+
+**Package convention for enums:**
+Two categories coexist in the domain:
+- Enums with behavioral methods (state machine transitions, promotion logic) live in `domain/vo/`: `UserStatus`, `AccountStatus`, `KycLevel`
+- Simple classification enums without behavior live in `domain/model/enums/`: `UserRole`, `AccountType`
+
+**`User.create()` accepts pre-constructed Value Objects, not raw Strings.**
+The factory signature is `User.create(Username, Email, String passwordHash)`. VO construction (`new Email(...)`, `new Username(...)`) is the caller's (use case's) responsibility. The ADR-007 example showed raw Strings for illustration only — the actual implementation is intentionally different.
+
+**`Account` uses `ownerId` instead of `userId`.**
+The entity field and port methods use `ownerId` to remain forward-compatible with ADR-008's deferred `OwnerType` (USER, AGENT, MERCHANT). MVP only supports USER, but the naming is intentional.
+
+**`KycLevel.isEligibleForAmount(BigDecimal)` is deliberately absent.**
+Amount limits are owned by ABAC policies (transfer-policies.yml), not the domain model. Placing limit enforcement in the domain would duplicate and potentially diverge from the policy engine. KycLevel carries only promotion logic — authorization decisions belong to the PDP.

--- a/docs/adr/ADR-007-uuid-v7-strategy.md
+++ b/docs/adr/ADR-007-uuid-v7-strategy.md
@@ -1,0 +1,64 @@
+# ADR-007: UUID v7 as Primary Key Strategy
+
+## Status
+Accepted
+
+## Context
+The Ciphernance services require globally unique identifiers for all domain entities (User, Account, Transaction, etc.). The standard Java UUID.randomUUID() generates UUID v4 — random, non-sortable identifiers.
+
+In relational databases (PostgreSQL), random UUID v4 as primary keys causes index fragmentation due to non-sequential inserts on B-tree indexes, leading to page splits and degraded write performance at scale.
+
+Three alternatives were evaluated:
+- UUID v4 (Java native) — random, no ordering guarantee, index fragmentation at scale
+- UUID v7 (java-uuid-generator library) — timestamp-based, lexicographically sortable, minimal overhead
+- Manual UUID v7 implementation — no dependency, but maintenance burden and risk of spec deviation
+
+Java 24 introduces native UUID v7 support via JEP 490, but Ciphernance targets Java 21 LTS.
+
+## Decision
+Use UUID v7 generated via the `java-uuid-generator` library (com.fasterxml.uuid:java-uuid-generator:4.3.0).
+
+The generator is called directly inside domain factory methods. A dedicated UuidV7 utility class was intentionally avoided to reduce boilerplate.
+
+When Java 24+ is adopted, migration requires updating each factory method individually rather than a single utility class.
+
+## Consequences
+
+**Gains:**
+- Lexicographically sortable identifiers — natural ordering by creation time
+- Reduced B-tree index fragmentation on PostgreSQL
+- Single dependency, mature library, production-proven
+
+**Costs:**
+- External dependency on java-uuid-generator
+- Domain layer is coupled to the library — migration to Java 24 native UUID v7 requires touching each factory method
+- Team must be aware not to use UUID.randomUUID() directly
+
+## Implementation
+
+```java
+// Direct usage inside domain factory methods
+// Example: User.create() in identity-service
+public static User create(String username, String email, String passwordHash) {
+    Email userEmail = new Email(email);
+    Username userUsername = new Username(username);
+    Instant now = Instant.now();
+
+    return new User(
+        Generators.timeBasedEpochGenerator().generate(),
+        userUsername,
+        userEmail,
+        passwordHash,
+        UserRole.USER_ROLE,
+        KycLevel.KYC_LEVEL_1,
+        false,
+        null,
+        UserStatus.ACTIVE,
+        now,
+        now
+    );
+}
+```
+
+## Migration Path
+When Java 24+ is adopted, replace Generators.timeBasedEpochGenerator().generate() with the native Java UUID v7 API in each factory method.

--- a/docs/adr/ADR-008-domain-model-user-account-wallet-balance.md
+++ b/docs/adr/ADR-008-domain-model-user-account-wallet-balance.md
@@ -1,0 +1,42 @@
+# ADR-008: Domain Model — User, Account, Wallet, Balance
+
+## Status
+Accepted
+
+## Context
+Ciphernance is a payment engine, not a traditional bank. The domain model must support multiple assets (BRL, ZEC, USD) and multiple contexts per user (personal, business) without requiring a full rewrite.
+
+Initial modeling used Account with AccountNumber in a traditional banking style. This was too rigid for a payment engine that may serve brokers, agentic payment systems, and multi-asset scenarios.
+
+## Decision
+Adopt a four-layer domain model:
+
+User → Account(s) → Wallet(s) → Balance
+
+- User: authentication and authorization identity (Identity Service)
+- Account: identity anchor in the payment engine. A User may have multiple Accounts (personal, business). Owned by Identity Service.
+- Wallet: denominated in a single Asset. UNIQUE(accountId, asset) — one wallet per asset per Account. Asset is immutable after creation. Owned by Wallet Service.
+- Balance: financial state of a Wallet — available, reserved, pending. Owned by Wallet Service.
+
+AccountNumber as a banking concept was removed. The UUID is the technical identifier. Human-readable references are deferred to future.
+
+OwnerType (USER, AGENT, MERCHANT) is deferred — MVP only supports USER.
+
+## MVP Constraints
+- One User has one Account
+- One Account has one Wallet (BRL)
+- Account + Wallet created automatically on User registration
+- Single asset: BRL
+
+## Consequences
+
+**Gains:**
+- Extensible to multi-asset without structural refactoring
+- Supports multiple Accounts per User (personal/business contexts) naturally
+- Clean separation between identity (Account) and financial state (Wallet/Balance)
+- Aligned with how payment processors (Stripe, Adyen) model accounts
+
+**Costs:**
+- More layers than a simple bank account model
+- Wallet Service must listen to AccountCreatedEvent to create its own projection
+- Balance as separate concept adds complexity vs a single balance field

--- a/services/identity-service/.gitignore
+++ b/services/identity-service/.gitignore
@@ -3,6 +3,7 @@ target/
 .mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
+.claude
 
 ### STS ###
 .apt_generated

--- a/services/identity-service/pom.xml
+++ b/services/identity-service/pom.xml
@@ -36,6 +36,14 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
+        <!-- ID -->
+
+        <dependency>
+            <groupId>com.fasterxml.uuid</groupId>
+            <artifactId>java-uuid-generator</artifactId>
+            <version>4.3.0</version>
+        </dependency>
+
         <!-- Security -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/event/AccountCreatedEvent.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/event/AccountCreatedEvent.java
@@ -1,0 +1,22 @@
+package io.ciphernance.identity.domain.event;
+
+import io.ciphernance.identity.domain.model.enums.AccountType;
+import io.ciphernance.identity.domain.vo.AccountStatus;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record AccountCreatedEvent(
+        UUID eventId,
+        UUID aggregateId,
+        UUID ownerId,
+        AccountType type,
+        AccountStatus status,
+        Instant occurredAt
+) implements DomainEvent {
+
+    @Override
+    public String eventType() {
+        return "ACCOUNT_CREATED";
+    }
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/event/AccountStatusChangedEvent.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/event/AccountStatusChangedEvent.java
@@ -1,6 +1,5 @@
 package io.ciphernance.identity.domain.event;
 
-import io.ciphernance.identity.domain.model.enums.AccountType;
 import io.ciphernance.identity.domain.vo.AccountStatus;
 
 import java.time.Instant;

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/event/AccountStatusChangedEvent.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/event/AccountStatusChangedEvent.java
@@ -1,0 +1,22 @@
+package io.ciphernance.identity.domain.event;
+
+import io.ciphernance.identity.domain.model.enums.AccountType;
+import io.ciphernance.identity.domain.vo.AccountStatus;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record AccountStatusChangedEvent(
+        UUID eventId,
+        UUID aggregateId,
+        UUID ownerId,
+        AccountStatus previousStatus,
+        AccountStatus newStatus,
+        Instant occurredAt
+) implements DomainEvent {
+
+    @Override
+    public String eventType() {
+        return "ACCOUNT_STATUS_CHANGED";
+    }
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/event/DomainEvent.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/event/DomainEvent.java
@@ -1,0 +1,12 @@
+package io.ciphernance.identity.domain.event;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public interface DomainEvent {
+
+    UUID eventId();
+    UUID aggregateId();
+    Instant occurredAt();
+    String eventType();
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/event/KycLevelUpdatedEvent.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/event/KycLevelUpdatedEvent.java
@@ -1,0 +1,20 @@
+package io.ciphernance.identity.domain.event;
+
+import io.ciphernance.identity.domain.vo.KycLevel;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record KycLevelUpdatedEvent(
+        UUID eventId,
+        UUID aggregateId,
+        KycLevel previousLevel,
+        KycLevel newLevel,
+        Instant occurredAt
+) implements DomainEvent {
+
+    @Override
+    public String eventType() {
+        return "KYC_LEVEL_UPDATED";
+    }
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/event/MfaDisabledEvent.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/event/MfaDisabledEvent.java
@@ -1,0 +1,16 @@
+package io.ciphernance.identity.domain.event;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record MfaDisabledEvent(
+        UUID eventId,
+        UUID aggregateId,
+        Instant occurredAt
+) implements DomainEvent {
+
+    @Override
+    public String eventType() {
+        return "MFA_DISABLED";
+    }
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/event/MfaEnabledEvent.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/event/MfaEnabledEvent.java
@@ -1,0 +1,16 @@
+package io.ciphernance.identity.domain.event;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record MfaEnabledEvent(
+        UUID eventId,
+        UUID aggregateId,
+        Instant occurredAt
+) implements DomainEvent {
+
+    @Override
+    public String eventType() {
+        return "MFA_ENABLED";
+    }
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/event/UserRegisteredEvent.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/event/UserRegisteredEvent.java
@@ -1,0 +1,21 @@
+package io.ciphernance.identity.domain.event;
+
+import io.ciphernance.identity.domain.vo.Email;
+import io.ciphernance.identity.domain.vo.Username;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record UserRegisteredEvent(
+        UUID eventId,
+        UUID aggregateId,
+        Username username,
+        Email email,
+        Instant occurredAt
+) implements DomainEvent {
+
+    @Override
+    public String eventType() {
+        return "USER_REGISTERED";
+    }
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/event/UserRoleChangedEvent.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/event/UserRoleChangedEvent.java
@@ -1,0 +1,20 @@
+package io.ciphernance.identity.domain.event;
+
+import io.ciphernance.identity.domain.model.enums.UserRole;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record UserRoleChangedEvent(
+        UUID eventId,
+        UUID aggregateId,
+        UserRole previousRole,
+        UserRole newRole,
+        Instant occurredAt
+) implements DomainEvent {
+
+    @Override
+    public String eventType() {
+        return "USER_ROLE_CHANGED";
+    }
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/event/UserStatusChangedEvent.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/event/UserStatusChangedEvent.java
@@ -1,0 +1,20 @@
+package io.ciphernance.identity.domain.event;
+
+import io.ciphernance.identity.domain.vo.UserStatus;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record UserStatusChangedEvent(
+        UUID eventId,
+        UUID aggregateId,
+        UserStatus previousStatus,
+        UserStatus newStatus,
+        Instant occurredAt
+) implements DomainEvent {
+
+    @Override
+    public String eventType() {
+        return "USER_STATUS_CHANGED";
+    }
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/InvalidAccountStatusTransitionException.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/InvalidAccountStatusTransitionException.java
@@ -1,0 +1,9 @@
+package io.ciphernance.identity.domain.exception;
+
+import io.ciphernance.identity.domain.vo.AccountStatus;
+
+public class InvalidAccountStatusTransitionException extends RuntimeException {
+    public InvalidAccountStatusTransitionException(AccountStatus currentStatus, AccountStatus newStatus) {
+        super("Invalid Account Status transition from " + currentStatus + " to " + newStatus);
+    }
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/InvalidEmailException.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/InvalidEmailException.java
@@ -1,0 +1,7 @@
+package io.ciphernance.identity.domain.exception;
+
+public class InvalidEmailException extends RuntimeException {
+    public InvalidEmailException(String message) {
+        super(message);
+    }
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/InvalidKycPromotionException.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/InvalidKycPromotionException.java
@@ -1,0 +1,9 @@
+package io.ciphernance.identity.domain.exception;
+
+import io.ciphernance.identity.domain.vo.KycLevel;
+
+public class InvalidKycPromotionException extends RuntimeException {
+    public InvalidKycPromotionException(KycLevel currentLevel, KycLevel newLevel) {
+        super("Invalid KYC level transition from " + currentLevel + " to " + newLevel);
+    }
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/InvalidMfaExeception.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/InvalidMfaExeception.java
@@ -1,0 +1,7 @@
+package io.ciphernance.identity.domain.exception;
+
+public class InvalidMfaExeception extends RuntimeException {
+    public InvalidMfaExeception(String message) {
+        super(message);
+    }
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/InvalidPasswordException.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/InvalidPasswordException.java
@@ -1,0 +1,7 @@
+package io.ciphernance.identity.domain.exception;
+
+public class InvalidPasswordException extends RuntimeException {
+    public InvalidPasswordException(String message) {
+        super(message);
+    }
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/InvalidRolePromotionException.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/InvalidRolePromotionException.java
@@ -1,0 +1,11 @@
+package io.ciphernance.identity.domain.exception;
+
+import io.ciphernance.identity.domain.model.enums.UserRole;
+
+import java.util.UUID;
+
+public class InvalidRolePromotionException extends RuntimeException {
+    public InvalidRolePromotionException(UUID userId, UserRole role) {
+        super("User " + userId + " cannot promote to Role " + role);
+    }
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/InvalidRoleRevokeException.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/InvalidRoleRevokeException.java
@@ -1,0 +1,11 @@
+package io.ciphernance.identity.domain.exception;
+
+import io.ciphernance.identity.domain.model.enums.UserRole;
+
+import java.util.UUID;
+
+public class InvalidRoleRevokeException extends RuntimeException {
+    public InvalidRoleRevokeException(UUID id, UserRole role) {
+        super("User " + id + " cannot revoke to Role " + role);
+    }
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/InvalidStatusTransitionException.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/InvalidStatusTransitionException.java
@@ -1,9 +1,0 @@
-package io.ciphernance.identity.domain.exception;
-
-import io.ciphernance.identity.domain.vo.UserStatus;
-
-public class InvalidStatusTransitionException extends RuntimeException {
-    public InvalidStatusTransitionException(UserStatus currentStatus, UserStatus newStatus) {
-        super("Invalid user status transition from " + currentStatus + " to " + newStatus);
-    }
-}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/InvalidStatusTransitionException.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/InvalidStatusTransitionException.java
@@ -1,0 +1,9 @@
+package io.ciphernance.identity.domain.exception;
+
+import io.ciphernance.identity.domain.vo.UserStatus;
+
+public class InvalidStatusTransitionException extends RuntimeException {
+    public InvalidStatusTransitionException(UserStatus currentStatus, UserStatus newStatus) {
+        super("Invalid user status transition from " + currentStatus + " to " + newStatus);
+    }
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/InvalidUserStatusTransitionException.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/InvalidUserStatusTransitionException.java
@@ -1,0 +1,9 @@
+package io.ciphernance.identity.domain.exception;
+
+import io.ciphernance.identity.domain.vo.UserStatus;
+
+public class InvalidUserStatusTransitionException extends RuntimeException {
+    public InvalidUserStatusTransitionException(UserStatus currentStatus, UserStatus newStatus) {
+        super("Invalid User Status transition from " + currentStatus + " to " + newStatus);
+    }
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/InvalidUsernameException.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/InvalidUsernameException.java
@@ -1,0 +1,7 @@
+package io.ciphernance.identity.domain.exception;
+
+public class InvalidUsernameException extends RuntimeException {
+    public InvalidUsernameException(String message) {
+        super(message);
+    }
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/MfaAlreadyEnabledException.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/MfaAlreadyEnabledException.java
@@ -1,0 +1,9 @@
+package io.ciphernance.identity.domain.exception;
+
+import java.util.UUID;
+
+public class MfaAlreadyEnabledException extends RuntimeException {
+    public MfaAlreadyEnabledException(UUID userId) {
+        super("User " + userId + " is already MFA enabled");
+    }
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/MfaNotEnabledException.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/exception/MfaNotEnabledException.java
@@ -1,0 +1,9 @@
+package io.ciphernance.identity.domain.exception;
+
+import java.util.UUID;
+
+public class MfaNotEnabledException extends RuntimeException {
+    public MfaNotEnabledException(UUID userId) {
+        super("User " + userId + " is not MFA enabled");
+    }
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/Account.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/Account.java
@@ -1,0 +1,4 @@
+package io.ciphernance.identity.domain.model;
+
+public class Account {
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/Account.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/Account.java
@@ -1,4 +1,80 @@
 package io.ciphernance.identity.domain.model;
 
+import com.fasterxml.uuid.Generators;
+import io.ciphernance.identity.domain.exception.InvalidAccountStatusTransitionException;
+import io.ciphernance.identity.domain.model.enums.AccountType;
+import io.ciphernance.identity.domain.vo.AccountStatus;
+
+import java.time.Instant;
+import java.util.UUID;
+
 public class Account {
+
+    private final UUID id;
+    private final UUID ownerId;
+    private final AccountType type;
+    private AccountStatus status;
+    private final Instant createdAt;
+    private Instant updatedAt;
+
+    private Account(UUID id,
+                    UUID ownerId,
+                    AccountType type,
+                    AccountStatus status,
+                    Instant createdAt,
+                    Instant updatedAt) {
+
+        this.id = id;
+        this.ownerId = ownerId;
+        this.type = type;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static Account createFor(UUID userId,
+                                    AccountType type) {
+
+        Instant now = Instant.now();
+
+        return new Account(Generators.timeBasedEpochGenerator().generate(),
+                userId,
+                type,
+                AccountStatus.ACTIVE,
+                now,
+                now
+        );
+    }
+
+    public static Account restore(UUID id,
+                                  UUID userId,
+                                  AccountType type,
+                                  AccountStatus status,
+                                  Instant createdAt,
+                                  Instant updatedAt) {
+
+        return new Account(id, userId, type,
+                status, createdAt, updatedAt);
+    }
+
+    public void block() {
+        transitionTo(AccountStatus.BLOCKED);
+    }
+
+    public void underAnalysis() {
+        transitionTo(AccountStatus.UNDER_ANALYSIS);
+    }
+
+    public void activate() {
+        transitionTo(AccountStatus.ACTIVE);
+    }
+
+    private void transitionTo(AccountStatus next) {
+        if (!this.status.canTransitionTo(next)) {
+            throw new InvalidAccountStatusTransitionException(this.status, next);
+        }
+
+        this.status = next;
+        this.updatedAt = Instant.now();
+    }
 }

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/Account.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/Account.java
@@ -32,14 +32,13 @@ public class Account {
         this.updatedAt = updatedAt;
     }
 
-    public static Account createFor(UUID userId,
-                                    AccountType type) {
+    public static Account createFor(UUID ownerId) {
 
         Instant now = Instant.now();
 
         return new Account(Generators.timeBasedEpochGenerator().generate(),
-                userId,
-                type,
+                ownerId,
+                AccountType.CHECKING,
                 AccountStatus.ACTIVE,
                 now,
                 now
@@ -47,13 +46,13 @@ public class Account {
     }
 
     public static Account restore(UUID id,
-                                  UUID userId,
+                                  UUID ownerId,
                                   AccountType type,
                                   AccountStatus status,
                                   Instant createdAt,
                                   Instant updatedAt) {
 
-        return new Account(id, userId, type,
+        return new Account(id, ownerId, type,
                 status, createdAt, updatedAt);
     }
 
@@ -76,5 +75,29 @@ public class Account {
 
         this.status = next;
         this.updatedAt = Instant.now();
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public UUID getOwnerId() {
+        return ownerId;
+    }
+
+    public AccountType getType() {
+        return type;
+    }
+
+    public AccountStatus getStatus() {
+        return status;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
     }
 }

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/User.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/User.java
@@ -1,7 +1,11 @@
 package io.ciphernance.identity.domain.model;
 
+import com.fasterxml.uuid.Generators;
+import io.ciphernance.identity.domain.exception.*;
 import io.ciphernance.identity.domain.model.enums.UserRole;
 import io.ciphernance.identity.domain.vo.Email;
+import io.ciphernance.identity.domain.vo.KycLevel;
+import io.ciphernance.identity.domain.vo.UserStatus;
 import io.ciphernance.identity.domain.vo.Username;
 
 import java.time.Instant;
@@ -14,8 +18,10 @@ public class User {
     private Email email;
     private String passwordHash;
     private UserRole role;
+    private KycLevel kycLevel;
     private boolean mfaEnabled;
     private String mfaSecret;
+    private UserStatus status;
     private Instant createdAt;
     private Instant updatedAt;
 
@@ -24,8 +30,10 @@ public class User {
                 Email email,
                 String passwordHash,
                 UserRole role,
+                 KycLevel kycLevel,
                 boolean mfaEnabled,
                 String mfaSecret,
+                UserStatus status,
                 Instant createdAt,
                 Instant updatedAt) {
 
@@ -34,9 +42,131 @@ public class User {
         this.email = email;
         this.passwordHash = passwordHash;
         this.role = role;
+        this.kycLevel = kycLevel;
         this.mfaEnabled = mfaEnabled;
         this.mfaSecret = mfaSecret;
+        this.status = status;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
+
+    public static User create(String username,
+            String email,
+            String passwordHash) {
+
+        Email userEmail = new Email(email);
+        Username userUsername = new Username(username);
+        Instant now = Instant.now();
+
+        return new User(
+                Generators.timeBasedEpochGenerator().generate(),
+                userUsername,
+                userEmail,
+                passwordHash,
+                UserRole.USER_ROLE,
+                KycLevel.KYC_LEVEL_1,
+                false,
+                null,
+                UserStatus.ACTIVE,
+                now,
+                now
+        );
+    }
+
+    public static User restore(UUID id,
+                               Username username,
+                               Email email,
+                               String passwordHash,
+                               UserRole role,
+                               KycLevel kycLevel,
+                               boolean mfaEnabled,
+                               String mfaSecret,
+                               UserStatus status,
+                               Instant createdAt,
+                               Instant updatedAt) {
+
+        return new User(id, username, email, passwordHash,
+                role, kycLevel, mfaEnabled, mfaSecret,
+                status, createdAt, updatedAt);
+    }
+
+    public void promoteToAdmin() {
+        if (this.role == UserRole.ADMIN_ROLE) {
+            throw new InvalidRolePromotionException(this.id, this.role);
+        }
+
+        this.role = UserRole.ADMIN_ROLE;
+        this.updatedAt = Instant.now();
+    }
+
+    public void revokeAdmin() {
+        if (this.role == UserRole.USER_ROLE) {
+            throw new InvalidRoleRevokeException(this.id, this.role);
+        }
+
+        this.role = UserRole.USER_ROLE;
+        this.updatedAt = Instant.now();
+    }
+
+    public void block() {
+        transitionTo(UserStatus.BLOCKED);
+    }
+
+    public void suspend() {
+        transitionTo(UserStatus.SUSPENDED);
+    }
+
+    public void activate() {
+        transitionTo(UserStatus.ACTIVE);
+    }
+
+    private void transitionTo(UserStatus next) {
+        if (!this.status.canTransitionTo(next)) {
+            throw new InvalidStatusTransitionException(this.status, next);
+        }
+
+        this.status = next;
+        this.updatedAt = Instant.now();
+    }
+
+    public void promoteKyc(KycLevel newLevel) {
+        if (newLevel.ordinal() <= this.kycLevel.ordinal()) {
+            throw new InvalidKycPromotionException(this.kycLevel, newLevel);
+        }
+
+        this.kycLevel = newLevel;
+        this.updatedAt = Instant.now();
+    }
+
+    public void enableMfa(String secret) {
+        if (this.mfaEnabled) {
+            throw new MfaAlreadyEnabledException(this.id);
+        }
+
+        this.mfaSecret = secret;
+        this.mfaEnabled = true;
+        this.updatedAt = Instant.now();
+    }
+
+    public void disableMfa() {
+        if (!this.mfaEnabled) {
+            throw new MfaNotEnabledException(this.id);
+        }
+
+        this.mfaSecret = null;
+        this.mfaEnabled = false;
+        this.updatedAt = Instant.now();
+    }
+
+    public UUID getId() { return id; }
+    public Username getUsername() { return username; }
+    public Email getEmail() { return email; }
+    public String getPasswordHash() { return passwordHash; }
+    public UserRole getRole() { return role; }
+    public KycLevel getKycLevel() { return kycLevel; }
+    public boolean isMfaEnabled() { return mfaEnabled; }
+    public String getMfaSecret() { return mfaSecret; }
+    public UserStatus getStatus() { return status; }
+    public Instant getCreatedAt() { return createdAt; }
+    public Instant getUpdatedAt() { return updatedAt; }
 }

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/User.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/User.java
@@ -1,0 +1,4 @@
+package io.ciphernance.identity.domain.model;
+
+public class User {
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/User.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/User.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 public class User {
 
     private final UUID id;
-    private Username username;
+    private final Username username;
     private final Email email;
     private String passwordHash;
     private UserRole role;
@@ -82,6 +82,12 @@ public class User {
                                UserStatus status,
                                Instant createdAt,
                                Instant updatedAt) {
+
+        if (mfaEnabled && (mfaSecret == null || mfaSecret.isBlank())) {
+            throw new IllegalStateException(
+                    "Cannot restore User with mfaEnabled=true and null mfaSecret"
+            );
+        }
 
         return new User(id, username, email, passwordHash,
                 role, kycLevel, mfaEnabled, mfaSecret,

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/User.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/User.java
@@ -1,4 +1,42 @@
 package io.ciphernance.identity.domain.model;
 
+import io.ciphernance.identity.domain.model.enums.UserRole;
+import io.ciphernance.identity.domain.vo.Email;
+import io.ciphernance.identity.domain.vo.Username;
+
+import java.time.Instant;
+import java.util.UUID;
+
 public class User {
+
+    private UUID id;
+    private Username username;
+    private Email email;
+    private String passwordHash;
+    private UserRole role;
+    private boolean mfaEnabled;
+    private String mfaSecret;
+    private Instant createdAt;
+    private Instant updatedAt;
+
+    private User(UUID id,
+                Username username,
+                Email email,
+                String passwordHash,
+                UserRole role,
+                boolean mfaEnabled,
+                String mfaSecret,
+                Instant createdAt,
+                Instant updatedAt) {
+
+        this.id = id;
+        this.username = username;
+        this.email = email;
+        this.passwordHash = passwordHash;
+        this.role = role;
+        this.mfaEnabled = mfaEnabled;
+        this.mfaSecret = mfaSecret;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
 }

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/User.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/User.java
@@ -56,6 +56,10 @@ public class User {
 
         Instant now = Instant.now();
 
+        if (passwordHash == null || passwordHash.isBlank()) {
+            throw new InvalidPasswordException("Password must not be blank");
+        }
+
         return new User(
                 Generators.timeBasedEpochGenerator().generate(),
                 username,
@@ -134,7 +138,7 @@ public class User {
     }
 
     public void promoteKyc(KycLevel newLevel) {
-        if (newLevel.ordinal() <= this.kycLevel.ordinal()) {
+        if (!this.kycLevel.canPromoteTo(newLevel)) {
             throw new InvalidKycPromotionException(this.kycLevel, newLevel);
         }
 

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/User.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/User.java
@@ -50,18 +50,16 @@ public class User {
         this.updatedAt = updatedAt;
     }
 
-    public static User create(String username,
-            String email,
-            String passwordHash) {
+    public static User create(Username username,
+                              Email email,
+                              String passwordHash) {
 
-        Email userEmail = new Email(email);
-        Username userUsername = new Username(username);
         Instant now = Instant.now();
 
         return new User(
                 Generators.timeBasedEpochGenerator().generate(),
-                userUsername,
-                userEmail,
+                username,
+                email,
                 passwordHash,
                 UserRole.USER_ROLE,
                 KycLevel.KYC_LEVEL_1,

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/User.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/User.java
@@ -13,16 +13,16 @@ import java.util.UUID;
 
 public class User {
 
-    private UUID id;
+    private final UUID id;
     private Username username;
-    private Email email;
+    private final Email email;
     private String passwordHash;
     private UserRole role;
     private KycLevel kycLevel;
     private boolean mfaEnabled;
     private String mfaSecret;
     private UserStatus status;
-    private Instant createdAt;
+    private final Instant createdAt;
     private Instant updatedAt;
 
     private User(UUID id,

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/User.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/User.java
@@ -120,7 +120,7 @@ public class User {
 
     private void transitionTo(UserStatus next) {
         if (!this.status.canTransitionTo(next)) {
-            throw new InvalidStatusTransitionException(this.status, next);
+            throw new InvalidUserStatusTransitionException(this.status, next);
         }
 
         this.status = next;

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/User.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/User.java
@@ -88,9 +88,7 @@ public class User {
                                Instant updatedAt) {
 
         if (mfaEnabled && (mfaSecret == null || mfaSecret.isBlank())) {
-            throw new IllegalStateException(
-                    "Cannot restore User with mfaEnabled=true and null mfaSecret"
-            );
+            throw new InvalidMfaExeception("Cannot restore User with a MFA enabled and null MFA secret");
         }
 
         return new User(id, username, email, passwordHash,

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/enums/AccountType.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/enums/AccountType.java
@@ -1,0 +1,6 @@
+package io.ciphernance.identity.domain.model.enums;
+
+public enum AccountType {
+
+    CHECKING
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/enums/UserRole.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/enums/UserRole.java
@@ -1,4 +1,7 @@
 package io.ciphernance.identity.domain.model.enums;
 
 public enum UserRole {
+
+    USER_ROLE,
+    ADMIN_ROLE
 }

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/enums/UserRole.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/model/enums/UserRole.java
@@ -1,0 +1,4 @@
+package io.ciphernance.identity.domain.model.enums;
+
+public enum UserRole {
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/ports/AccountRepositoryPort.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/ports/AccountRepositoryPort.java
@@ -9,6 +9,6 @@ public interface AccountRepositoryPort {
 
     Account save(Account account);
     Optional<Account> findById(UUID id);
-    Optional<Account> findByUserId(UUID userId);
-    boolean existsByUserId(UUID userId);
+    Optional<Account> findByOwnerId(UUID userId);
+    boolean existsByOwnerId(UUID userId);
 }

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/ports/AccountRepositoryPort.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/ports/AccountRepositoryPort.java
@@ -1,0 +1,14 @@
+package io.ciphernance.identity.domain.ports;
+
+import io.ciphernance.identity.domain.model.Account;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface AccountRepositoryPort {
+
+    Account save(Account account);
+    Optional<Account> findById(UUID id);
+    Optional<Account> findByUserId(UUID userId);
+    boolean existsByUserId(UUID userId);
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/ports/EventPublisherPort.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/ports/EventPublisherPort.java
@@ -1,0 +1,11 @@
+package io.ciphernance.identity.domain.ports;
+
+import io.ciphernance.identity.domain.event.DomainEvent;
+
+import java.util.List;
+
+public interface EventPublisherPort {
+
+    void publish(DomainEvent event);
+    void publishAll(List<DomainEvent> events);
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/ports/UserRepositoryPort.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/ports/UserRepositoryPort.java
@@ -1,0 +1,18 @@
+package io.ciphernance.identity.domain.ports;
+
+import io.ciphernance.identity.domain.model.User;
+import io.ciphernance.identity.domain.vo.Email;
+import io.ciphernance.identity.domain.vo.Username;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepositoryPort {
+
+    User save(User user);
+    Optional<User> findById(UUID id);
+    Optional<User> findByUsername(Username username);
+    Optional<User> findByEmail(Email email);
+    boolean existsByUsername(Username username);
+    boolean existsByEmail(Email email);
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/AccountNumber.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/AccountNumber.java
@@ -1,0 +1,4 @@
+package io.ciphernance.identity.domain.vo;
+
+public class AccountNumber {
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/AccountNumber.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/AccountNumber.java
@@ -1,4 +1,0 @@
-package io.ciphernance.identity.domain.vo;
-
-public class AccountNumber {
-}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/AccountStatus.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/AccountStatus.java
@@ -1,0 +1,4 @@
+package io.ciphernance.identity.domain.vo;
+
+public class AccountStatus {
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/AccountStatus.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/AccountStatus.java
@@ -1,4 +1,33 @@
 package io.ciphernance.identity.domain.vo;
 
-public class AccountStatus {
+import java.util.Set;
+
+public enum AccountStatus {
+
+    ACTIVE {
+        @Override
+        public Set<AccountStatus> allowedTransitions() {
+            return Set.of(UNDER_ANALYSIS, BLOCKED);
+        }
+    },
+
+    BLOCKED {
+        @Override
+        public Set<AccountStatus> allowedTransitions() {
+            return Set.of();
+        }
+    },
+
+    UNDER_ANALYSIS {
+        @Override
+        public Set<AccountStatus> allowedTransitions() {
+            return Set.of(ACTIVE, BLOCKED);
+        }
+    };
+
+    public abstract Set<AccountStatus> allowedTransitions();
+
+    public boolean canTransitionTo(AccountStatus next) {
+        return allowedTransitions().contains(next);
+    }
 }

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/Email.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/Email.java
@@ -1,4 +1,45 @@
 package io.ciphernance.identity.domain.vo;
 
-public class Email {
+import io.ciphernance.identity.domain.exception.InvalidEmailException;
+
+import java.util.regex.Pattern;
+
+public final class Email {
+
+    private static final Pattern EMAIL_PATTERN =
+            Pattern.compile("^[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}$");
+
+    private final String value;
+
+    public Email(String value) {
+        if (value == null || value.isBlank()) {
+            throw new InvalidEmailException("Email must not be blank");
+        }
+        String normalized = value.strip().toLowerCase();
+        if (!EMAIL_PATTERN.matcher(normalized).matches()) {
+            throw new InvalidEmailException("Invalid email format: " + value);
+        }
+        this.value = normalized;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Email email)) return false;
+        return value.equals(email.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
 }

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/Email.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/Email.java
@@ -19,6 +19,7 @@ public final class Email {
         if (!EMAIL_PATTERN.matcher(normalized).matches()) {
             throw new InvalidEmailException("Invalid email format: " + value);
         }
+
         this.value = normalized;
     }
 

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/Email.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/Email.java
@@ -2,6 +2,7 @@ package io.ciphernance.identity.domain.vo;
 
 import io.ciphernance.identity.domain.exception.InvalidEmailException;
 
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 public final class Email {
@@ -15,7 +16,7 @@ public final class Email {
         if (value == null || value.isBlank()) {
             throw new InvalidEmailException("Email must not be blank");
         }
-        String normalized = value.strip().toLowerCase();
+        String normalized = value.strip().toLowerCase(Locale.ROOT);
         if (!EMAIL_PATTERN.matcher(normalized).matches()) {
             throw new InvalidEmailException("Invalid email format: " + value);
         }

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/Email.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/Email.java
@@ -1,0 +1,4 @@
+package io.ciphernance.identity.domain.vo;
+
+public class Email {
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/KycLevel.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/KycLevel.java
@@ -5,4 +5,8 @@ public enum KycLevel {
     KYC_LEVEL_1,
     KYC_LEVEL_2,
     KYC_LEVEL_3;
+
+    public boolean canPromoteTo(KycLevel next) {
+        return next.ordinal() > this.ordinal();
+    }
 }

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/KycLevel.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/KycLevel.java
@@ -1,4 +1,8 @@
 package io.ciphernance.identity.domain.vo;
 
-public class KycLevel {
+public enum KycLevel {
+
+    KYC_LEVEL_1,
+    KYC_LEVEL_2,
+    KYC_LEVEL_3;
 }

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/KycLevel.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/KycLevel.java
@@ -1,0 +1,4 @@
+package io.ciphernance.identity.domain.vo;
+
+public class KycLevel {
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/UserStatus.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/UserStatus.java
@@ -1,0 +1,4 @@
+package io.ciphernance.identity.domain.vo;
+
+public class UserStatus {
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/UserStatus.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/UserStatus.java
@@ -1,4 +1,33 @@
 package io.ciphernance.identity.domain.vo;
 
-public class UserStatus {
+import java.util.Set;
+
+public enum UserStatus {
+
+    ACTIVE {
+        @Override
+        public Set<UserStatus> allowedTransitions() {
+            return Set.of(SUSPENDED, BLOCKED);
+        }
+    },
+
+    SUSPENDED {
+        @Override
+        public Set<UserStatus> allowedTransitions() {
+            return Set.of(ACTIVE, BLOCKED);
+        }
+    },
+
+    BLOCKED {
+        @Override
+        public Set<UserStatus> allowedTransitions() {
+            return Set.of();
+        }
+    };
+
+    public abstract Set<UserStatus> allowedTransitions();
+
+    public boolean canTransitionTo(UserStatus next) {
+        return allowedTransitions().contains(next);
+    }
 }

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/Username.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/Username.java
@@ -1,0 +1,4 @@
+package io.ciphernance.identity.domain.vo;
+
+public class Username {
+}

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/Username.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/vo/Username.java
@@ -1,4 +1,45 @@
 package io.ciphernance.identity.domain.vo;
 
-public class Username {
+import io.ciphernance.identity.domain.exception.InvalidUsernameException;
+import java.util.regex.Pattern;
+
+public final class Username {
+
+    private static final Pattern USERNAME_PATTERN =
+            Pattern.compile("^[a-zA-Z0-9_]{3,50}$");
+
+    private final String value;
+
+    public Username(String value) {
+        if (value == null || value.isBlank()) {
+            throw new InvalidUsernameException("Username must not be blank");
+        }
+        if (!USERNAME_PATTERN.matcher(value).matches()) {
+            throw new InvalidUsernameException(
+                    "Username must be 3-50 characters, alphanumeric and underscore only: " + value
+            );
+        }
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Username username)) return false;
+        return value.equals(username.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
 }


### PR DESCRIPTION
## Summary
Implements the complete domain layer for the Identity Service following Clean/Hexagonal Architecture and DDD principles.

## What was implemented

### Domain Entities
- `User` — rich domain object with business behavior (status transitions, KYC promotion, MFA management, role management)
- `Account` — identity anchor in the payment engine (status transitions)
- Both entities use static factory methods (`create` / `restore`) with private constructors

### Value Objects
- `Email` — RFC format validation, normalized to lowercase, immutable
- `Username` — 3-50 chars, alphanumeric + underscore, immutable
- `KycLevel` — enum with `canPromoteTo()` business method
- `UserStatus` — enum with `canTransitionTo()` enforcing valid transitions
- `AccountStatus` — enum with `canTransitionTo()` enforcing valid transitions

### Domain Events
- `DomainEvent` base interface
- 6 User events: `UserRegisteredEvent`, `UserStatusChangedEvent`, `UserRoleChangedEvent`, `KycLevelUpdatedEvent`, `MfaEnabledEvent`, `MfaDisabledEvent`
- 2 Account events: `AccountCreatedEvent`, `AccountStatusChangedEvent`
- All events implemented as Java records — immutable by nature

### Output Ports
- `UserRepositoryPort` — 6 methods derived from concrete Use Cases
- `AccountRepositoryPort` — 4 methods derived from concrete Use Cases
- `EventPublisherPort` — stable generic contract (`publish` / `publishAll`)

## Architecture decisions applied
- ADR-007: UUID v7 via `java-uuid-generator` in domain factory methods
- ADR-008: Domain model User → Account → Wallet → Balance
- KycLevel limits removed from domain — enforced via ABAC policies (YAML)
- Identity Service has no knowledge of Wallet, Balance, or financial concepts
- Domain events created and published by Use Cases, not by entities

## What is NOT in this PR
- Application layer (Use Cases)
- Infrastructure layer (JPA adapters, Kafka publisher)
- Spring configuration
- Tests

## Checklist
- [x] No framework dependencies in domain layer
- [x] All Value Objects immutable
- [x] Status transitions enforced via `canTransitionTo()`
- [x] Factory methods correctly separated (create vs restore)
- [x] Output ports use only domain types
- [x] Domain events carry sufficient data without querying DB
- [x] CLAUDE.md updated to reflect implementation decisions