### PR TITLE
feat(identity-service): application layer, refactor for user-account status change using 1:1 logic for MVP

### DIFF
--- a/services/identity-service/src/main/java/io/ciphernance/identity/application/command/user/status/activate/ActivateUserHandler.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/application/command/user/status/activate/ActivateUserHandler.java
@@ -64,7 +64,7 @@ public class ActivateUserHandler implements CommandHandler<ActivateUserCommand, 
                 ),
                 new AccountStatusChangedEvent(
                         DomainEvent.newEventId(),
-                        user.getId(),
+                        account.getId(),
                         user.getId(),
                         previousAccountStatus,
                         account.getStatus(),

--- a/services/identity-service/src/main/java/io/ciphernance/identity/application/command/user/status/activate/ActivateUserHandler.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/application/command/user/status/activate/ActivateUserHandler.java
@@ -1,13 +1,18 @@
 package io.ciphernance.identity.application.command.user.status.activate;
 
+import io.ciphernance.identity.application.exception.account.AccountNotFoundException;
 import io.ciphernance.identity.application.exception.user.UserNotFoundException;
 import io.ciphernance.identity.application.mediator.CommandHandler;
 import io.ciphernance.identity.application.port.out.EventPublisherPort;
 import io.ciphernance.identity.domain.event.AccessRestoredEvent;
+import io.ciphernance.identity.domain.event.AccountStatusChangedEvent;
 import io.ciphernance.identity.domain.event.DomainEvent;
 import io.ciphernance.identity.domain.event.UserStatusChangedEvent;
+import io.ciphernance.identity.domain.model.Account;
 import io.ciphernance.identity.domain.model.User;
+import io.ciphernance.identity.domain.port.AccountRepositoryPort;
 import io.ciphernance.identity.domain.port.UserRepositoryPort;
+import io.ciphernance.identity.domain.vo.AccountStatus;
 import io.ciphernance.identity.domain.vo.UserStatus;
 import org.springframework.stereotype.Component;
 
@@ -17,13 +22,17 @@ import java.util.List;
 public class ActivateUserHandler implements CommandHandler<ActivateUserCommand, Void> {
 
     private final UserRepositoryPort userRepository;
+    private final AccountRepositoryPort accountRepository;
     private final EventPublisherPort eventPublisher;
 
-    public ActivateUserHandler(UserRepositoryPort userRepository, EventPublisherPort eventPublisher) {
+    public ActivateUserHandler(UserRepositoryPort userRepository,
+                               AccountRepositoryPort accountRepository,
+                               EventPublisherPort eventPublisher) {
+
         this.userRepository = userRepository;
+        this.accountRepository = accountRepository;
         this.eventPublisher = eventPublisher;
     }
-
 
     @Override
     public Void handle(ActivateUserCommand command) {
@@ -31,23 +40,40 @@ public class ActivateUserHandler implements CommandHandler<ActivateUserCommand, 
         User user = userRepository.findById(command.userId())
                 .orElseThrow(() -> new UserNotFoundException(command.userId()));
 
-        UserStatus previousStatus = user.getStatus();
+        UserStatus previousUserStatus = user.getStatus();
 
         user.activate();
 
+        Account account = accountRepository.findByOwnerId(user.getId())
+                .orElseThrow(() -> AccountNotFoundException.forOwner(command.userId()));
+
+        AccountStatus previousAccountStatus = account.getStatus();
+
+        account.activate();
+
         userRepository.save(user);
+        accountRepository.save(account);
 
         eventPublisher.publishAll(List.of(
                 new UserStatusChangedEvent(
                         DomainEvent.newEventId(),
                         user.getId(),
-                        previousStatus,
+                        previousUserStatus,
                         user.getStatus(),
                         user.getUpdatedAt()
+                ),
+                new AccountStatusChangedEvent(
+                        DomainEvent.newEventId(),
+                        user.getId(),
+                        user.getId(),
+                        previousAccountStatus,
+                        account.getStatus(),
+                        account.getUpdatedAt()
                 ),
                 new AccessRestoredEvent(
                         DomainEvent.newEventId(),
                         user.getId(),
+                        account.getId(),
                         user.getUpdatedAt()
                 )
         ));

--- a/services/identity-service/src/main/java/io/ciphernance/identity/application/command/user/status/block/BlockUserHandler.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/application/command/user/status/block/BlockUserHandler.java
@@ -4,10 +4,14 @@ import io.ciphernance.identity.application.exception.user.UserNotFoundException;
 import io.ciphernance.identity.application.mediator.CommandHandler;
 import io.ciphernance.identity.application.port.out.EventPublisherPort;
 import io.ciphernance.identity.domain.event.AccessRevokedEvent;
+import io.ciphernance.identity.domain.event.AccountStatusChangedEvent;
 import io.ciphernance.identity.domain.event.DomainEvent;
 import io.ciphernance.identity.domain.event.UserStatusChangedEvent;
+import io.ciphernance.identity.domain.model.Account;
 import io.ciphernance.identity.domain.model.User;
+import io.ciphernance.identity.domain.port.AccountRepositoryPort;
 import io.ciphernance.identity.domain.port.UserRepositoryPort;
+import io.ciphernance.identity.domain.vo.AccountStatus;
 import io.ciphernance.identity.domain.vo.UserStatus;
 import org.springframework.stereotype.Component;
 
@@ -17,10 +21,15 @@ import java.util.List;
 public class BlockUserHandler implements CommandHandler<BlockUserCommand, Void> {
 
     private final UserRepositoryPort userRepository;
+    private final AccountRepositoryPort accountRepository;
     private final EventPublisherPort eventPublisher;
 
-    public BlockUserHandler(UserRepositoryPort userRepository, EventPublisherPort eventPublisher) {
+    public BlockUserHandler(UserRepositoryPort userRepository,
+                            AccountRepositoryPort accountRepository,
+                            EventPublisherPort eventPublisher) {
+
         this.userRepository = userRepository;
+        this.accountRepository = accountRepository;
         this.eventPublisher = eventPublisher;
     }
 
@@ -30,9 +39,16 @@ public class BlockUserHandler implements CommandHandler<BlockUserCommand, Void> 
         User user = userRepository.findById(command.userId())
                 .orElseThrow(() -> new UserNotFoundException(command.userId()));
 
-        UserStatus previousStatus = user.getStatus();
+        UserStatus previousUserStatus = user.getStatus();
 
         user.block();
+
+        Account account = accountRepository.findByOwnerId(user.getId())
+                .orElseThrow(() -> new UserNotFoundException(command.userId()));
+
+        AccountStatus previousAccountStatus = account.getStatus();
+
+        account.block();
 
         userRepository.save(user);
 
@@ -40,13 +56,22 @@ public class BlockUserHandler implements CommandHandler<BlockUserCommand, Void> 
                 new UserStatusChangedEvent(
                         DomainEvent.newEventId(),
                         user.getId(),
-                        previousStatus,
+                        previousUserStatus,
                         user.getStatus(),
                         user.getUpdatedAt()
+                ),
+                new AccountStatusChangedEvent(
+                        DomainEvent.newEventId(),
+                        user.getId(),
+                        user.getId(),
+                        previousAccountStatus,
+                        account.getStatus(),
+                        account.getUpdatedAt()
                 ),
                 new AccessRevokedEvent(
                         DomainEvent.newEventId(),
                         user.getId(),
+                        account.getId(),
                         user.getUpdatedAt()
                 )
         ));

--- a/services/identity-service/src/main/java/io/ciphernance/identity/application/command/user/status/block/BlockUserHandler.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/application/command/user/status/block/BlockUserHandler.java
@@ -64,8 +64,8 @@ public class BlockUserHandler implements CommandHandler<BlockUserCommand, Void> 
                 ),
                 new AccountStatusChangedEvent(
                         DomainEvent.newEventId(),
-                        user.getId(),
                         account.getId(),
+                        user.getId(),
                         previousAccountStatus,
                         account.getStatus(),
                         account.getUpdatedAt()

--- a/services/identity-service/src/main/java/io/ciphernance/identity/application/command/user/status/block/BlockUserHandler.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/application/command/user/status/block/BlockUserHandler.java
@@ -1,5 +1,6 @@
 package io.ciphernance.identity.application.command.user.status.block;
 
+import io.ciphernance.identity.application.exception.account.AccountNotFoundException;
 import io.ciphernance.identity.application.exception.user.UserNotFoundException;
 import io.ciphernance.identity.application.mediator.CommandHandler;
 import io.ciphernance.identity.application.port.out.EventPublisherPort;
@@ -44,13 +45,14 @@ public class BlockUserHandler implements CommandHandler<BlockUserCommand, Void> 
         user.block();
 
         Account account = accountRepository.findByOwnerId(user.getId())
-                .orElseThrow(() -> new UserNotFoundException(command.userId()));
+                .orElseThrow(() -> AccountNotFoundException.forOwner(command.userId()));
 
         AccountStatus previousAccountStatus = account.getStatus();
 
         account.block();
 
         userRepository.save(user);
+        accountRepository.save(account);
 
         eventPublisher.publishAll(List.of(
                 new UserStatusChangedEvent(

--- a/services/identity-service/src/main/java/io/ciphernance/identity/application/command/user/status/block/BlockUserHandler.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/application/command/user/status/block/BlockUserHandler.java
@@ -65,7 +65,7 @@ public class BlockUserHandler implements CommandHandler<BlockUserCommand, Void> 
                 new AccountStatusChangedEvent(
                         DomainEvent.newEventId(),
                         user.getId(),
-                        user.getId(),
+                        account.getId(),
                         previousAccountStatus,
                         account.getStatus(),
                         account.getUpdatedAt()

--- a/services/identity-service/src/main/java/io/ciphernance/identity/application/command/user/status/suspend/SuspendUserHandler.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/application/command/user/status/suspend/SuspendUserHandler.java
@@ -1,13 +1,18 @@
 package io.ciphernance.identity.application.command.user.status.suspend;
 
+import io.ciphernance.identity.application.exception.account.AccountNotFoundException;
 import io.ciphernance.identity.application.exception.user.UserNotFoundException;
 import io.ciphernance.identity.application.mediator.CommandHandler;
 import io.ciphernance.identity.application.port.out.EventPublisherPort;
 import io.ciphernance.identity.domain.event.AccessRevokedEvent;
+import io.ciphernance.identity.domain.event.AccountStatusChangedEvent;
 import io.ciphernance.identity.domain.event.DomainEvent;
 import io.ciphernance.identity.domain.event.UserStatusChangedEvent;
+import io.ciphernance.identity.domain.model.Account;
 import io.ciphernance.identity.domain.model.User;
+import io.ciphernance.identity.domain.port.AccountRepositoryPort;
 import io.ciphernance.identity.domain.port.UserRepositoryPort;
+import io.ciphernance.identity.domain.vo.AccountStatus;
 import io.ciphernance.identity.domain.vo.UserStatus;
 import org.springframework.stereotype.Component;
 
@@ -17,10 +22,15 @@ import java.util.List;
 public class SuspendUserHandler implements CommandHandler<SuspendUserCommand, Void> {
 
     private final UserRepositoryPort userRepository;
+    private final AccountRepositoryPort accountRepository;
     private final EventPublisherPort eventPublisher;
 
-    public SuspendUserHandler(UserRepositoryPort userRepository, EventPublisherPort eventPublisher) {
+    public SuspendUserHandler(UserRepositoryPort userRepository,
+                              AccountRepositoryPort accountRepository,
+                              EventPublisherPort eventPublisher) {
+
         this.userRepository = userRepository;
+        this.accountRepository = accountRepository;
         this.eventPublisher = eventPublisher;
     }
 
@@ -30,23 +40,40 @@ public class SuspendUserHandler implements CommandHandler<SuspendUserCommand, Vo
         User user = userRepository.findById(command.userId())
                 .orElseThrow(() -> new UserNotFoundException(command.userId()));
 
-        UserStatus previousStatus = user.getStatus();
+        UserStatus previousUserStatus = user.getStatus();
 
         user.suspend();
 
+        Account account = accountRepository.findByOwnerId(user.getId())
+                .orElseThrow(() -> AccountNotFoundException.forOwner(command.userId()));
+
+        AccountStatus previousAccountStatus = account.getStatus();
+
+        account.underAnalysis();
+
         userRepository.save(user);
+        accountRepository.save(account);
 
         eventPublisher.publishAll(List.of(
                 new UserStatusChangedEvent(
                         DomainEvent.newEventId(),
                         user.getId(),
-                        previousStatus,
+                        previousUserStatus,
                         user.getStatus(),
                         user.getUpdatedAt()
+                ),
+                new AccountStatusChangedEvent(
+                        DomainEvent.newEventId(),
+                        user.getId(),
+                        user.getId(),
+                        previousAccountStatus,
+                        account.getStatus(),
+                        account.getUpdatedAt()
                 ),
                 new AccessRevokedEvent(
                         DomainEvent.newEventId(),
                         user.getId(),
+                        account.getId(),
                         user.getUpdatedAt()
                 )
         ));

--- a/services/identity-service/src/main/java/io/ciphernance/identity/application/command/user/status/suspend/SuspendUserHandler.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/application/command/user/status/suspend/SuspendUserHandler.java
@@ -64,7 +64,7 @@ public class SuspendUserHandler implements CommandHandler<SuspendUserCommand, Vo
                 ),
                 new AccountStatusChangedEvent(
                         DomainEvent.newEventId(),
-                        user.getId(),
+                        account.getId(),
                         user.getId(),
                         previousAccountStatus,
                         account.getStatus(),

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/event/AccessRestoredEvent.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/event/AccessRestoredEvent.java
@@ -7,6 +7,7 @@ public record AccessRestoredEvent(
 
         UUID eventId,
         UUID aggregateId,
+        UUID accountId,
         Instant occurredAt
 
 ) implements DomainEvent {

--- a/services/identity-service/src/main/java/io/ciphernance/identity/domain/event/AccessRevokedEvent.java
+++ b/services/identity-service/src/main/java/io/ciphernance/identity/domain/event/AccessRevokedEvent.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 public record AccessRevokedEvent(
         UUID eventId,
         UUID aggregateId,
+        UUID accountId,
         Instant occurredAt
 
 ) implements DomainEvent {


### PR DESCRIPTION
### Context

This pull request enhances the user status change handlers (`BlockUserHandler`, `SuspendUserHandler`, and `ActivateUserHandler`) to ensure that account status changes are synchronized with user status changes. It also improves event publishing by emitting new `AccountStatusChangedEvent` events and updating existing access events to include the account ID.

**User and Account Status Synchronization:**

* The handlers now retrieve the associated `Account` for a user and update its status in tandem with the user's status (e.g., blocking, suspending, or activating both the user and their account). (`BlockUserHandler.java`, `SuspendUserHandler.java`, `ActivateUserHandler.java`) [[1]](diffhunk://#diff-f82525c909b92cc900759f97027b4d252b4f5051ebb2299890ab2eb18fac09ddL33-R76) [[2]](diffhunk://#diff-39c796d6baf0766e8977b20f1b896b3a54ec2717e09865d8de1edccff5c40089L33-R76) [[3]](diffhunk://#diff-14027f59bce45716a6711fe4e0dd009d6bbe68940b74bcba6e928a59946f3102R25-R76)

* The account is saved after its status is changed, ensuring the persistence layer reflects these updates. (`BlockUserHandler.java`, `SuspendUserHandler.java`, `ActivateUserHandler.java`) [[1]](diffhunk://#diff-f82525c909b92cc900759f97027b4d252b4f5051ebb2299890ab2eb18fac09ddL33-R76) [[2]](diffhunk://#diff-39c796d6baf0766e8977b20f1b896b3a54ec2717e09865d8de1edccff5c40089L33-R76) [[3]](diffhunk://#diff-14027f59bce45716a6711fe4e0dd009d6bbe68940b74bcba6e928a59946f3102R25-R76)

**Event Publishing Enhancements:**

* A new `AccountStatusChangedEvent` is published whenever an account's status changes, alongside the existing `UserStatusChangedEvent` and access events. (`BlockUserHandler.java`, `SuspendUserHandler.java`, `ActivateUserHandler.java`) [[1]](diffhunk://#diff-f82525c909b92cc900759f97027b4d252b4f5051ebb2299890ab2eb18fac09ddL33-R76) [[2]](diffhunk://#diff-39c796d6baf0766e8977b20f1b896b3a54ec2717e09865d8de1edccff5c40089L33-R76) [[3]](diffhunk://#diff-14027f59bce45716a6711fe4e0dd009d6bbe68940b74bcba6e928a59946f3102R25-R76)

* The `AccessRevokedEvent` and `AccessRestoredEvent` records are updated to include the `accountId` field, and the handlers now supply the account ID when publishing these events. (`AccessRevokedEvent.java`, `AccessRestoredEvent.java`, `BlockUserHandler.java`, `SuspendUserHandler.java`, `ActivateUserHandler.java`) [[1]](diffhunk://#diff-4c47d1398afce1254979536962ca3802c99ce8c82c10989ac045fb6d39d5edd1R9) [[2]](diffhunk://#diff-e223d354c4258d9861641c2c4e4c8588aaad5022b3c5b99cf8425c928a4c53cbR10) [[3]](diffhunk://#diff-f82525c909b92cc900759f97027b4d252b4f5051ebb2299890ab2eb18fac09ddL33-R76) [[4]](diffhunk://#diff-39c796d6baf0766e8977b20f1b896b3a54ec2717e09865d8de1edccff5c40089L33-R76) [[5]](diffhunk://#diff-14027f59bce45716a6711fe4e0dd009d6bbe68940b74bcba6e928a59946f3102R25-R76)

**Dependency Injection Updates:**

* The handlers' constructors are updated to require an `AccountRepositoryPort` in addition to the existing dependencies, enabling account lookups and updates. (`BlockUserHandler.java`, `SuspendUserHandler.java`, `ActivateUserHandler.java`) [[1]](diffhunk://#diff-f82525c909b92cc900759f97027b4d252b4f5051ebb2299890ab2eb18fac09ddR25-R33) [[2]](diffhunk://#diff-39c796d6baf0766e8977b20f1b896b3a54ec2717e09865d8de1edccff5c40089R25-R33) [[3]](diffhunk://#diff-14027f59bce45716a6711fe4e0dd009d6bbe68940b74bcba6e928a59946f3102R25-R76)