### PR TITLE
docs: fix ADR inconsistencies and add ADR-013/014/015

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Under active development.
 - [x] Monorepo structure and ADRs
 - [x] Docker Compose infrastructure
 - [x] Identity Service — domain layer (User, Account, events, ports)
-- [ ] Identity Service — application layer (Use Cases)
+- [x] Identity Service — application layer (Commands, Queries, Mediator, Ports)
 - [ ] Identity Service — infrastructure layer (JPA, Kafka, Spring Security)
 - [ ] API Gateway
 - [ ] Wallet Service
@@ -91,11 +91,21 @@ Under active development.
 
 See [`/docs/adr`](./docs/adr) for the full records.
 
-- **Choreography-based Saga** — no central orchestrator; services react to and emit events autonomously
-- **Eventually Consistent Authorization** — each service runs a local Policy Agent with ABAC; Identity Service distributes policy updates via Kafka
-- **YAML ABAC policies** — human-readable DSL versioned in `/policies`, compiled and distributed at runtime
-- **Event Sourcing scoped to Transaction Service** — transaction state is the sum of its events; no other service uses this pattern
-- **UUID v7** — time-ordered identifiers for natural sort and indexing without sacrificing uniqueness
+| ADR | Decision |
+|-----|----------|
+| ADR-001 | Choreography-based Saga — no central orchestrator; services react to and emit events autonomously |
+| ADR-002 | Eventually Consistent Authorization — each service runs a local Policy Agent with ABAC |
+| ADR-003 | YAML ABAC policies — human-readable DSL versioned per service |
+| ADR-004 | Event Sourcing scoped to Transaction Service only |
+| ADR-005 | Two-level cache (L1 Caffeine + L2 Redis) for Policy Agents |
+| ADR-006 | No decision-level cache — every authorization is freshly evaluated |
+| ADR-007 | UUID v7 — time-ordered identifiers for natural sort and reduced index fragmentation |
+| ADR-008 | Domain Model — User → Account → Wallet → Balance across Identity and Wallet services |
+| ADR-009 | CQS via Mediator in Identity Service — Commands and Queries in separate handler classes |
+| ADR-010 | JWT session invalidation via Redis blocklist on access revocation |
+| ADR-013 | ABAC policies embedded per service; Identity Service distributes only dynamic attributes |
+| ADR-014 | Hexagonal Architecture (Ports and Adapters) — strict inward dependency direction |
+| ADR-015 | Exception hierarchy — domain exceptions for invariants, application exceptions for use cases |
 
 ---
 

--- a/docs/adr/ADR-001-choreography-saga.md
+++ b/docs/adr/ADR-001-choreography-saga.md
@@ -4,7 +4,7 @@
 Accepted
 
 ## Context
-Ciphernance must execute multi-step financial transactions (transfer Saga) that span multiple services: Transaction Service, Account Service, Fraud Service, and Identity Service. Each step must either complete successfully or trigger a full compensating rollback. In a microservices architecture, there is no shared database transaction — consistency must be achieved through coordination.
+Ciphernance must execute multi-step financial transactions (transfer Saga) that span multiple services: Transaction Service, Wallet Service, Fraud Service, and Identity Service. Each step must either complete successfully or trigger a full compensating rollback. In a microservices architecture, there is no shared database transaction — consistency must be achieved through coordination.
 
 Two Saga implementation styles exist: **orchestration** (a central coordinator issues commands to each participant) and **choreography** (each service reacts to events and publishes new events, with no central controller).
 
@@ -13,7 +13,7 @@ The choice directly impacts coupling, operational complexity, and the learning o
 ## Decision
 Adopt **choreography-based Saga**. Each service listens to Kafka topics, reacts to domain events, executes its local transaction, and publishes the outcome as a new event. There is no dedicated Saga orchestrator service. The Transaction Service acts as the logical initiator and terminator of the Saga but does not issue commands to other services — it publishes events they react to.
 
-Compensation (rollback) is also event-driven: a `FraudSuspectedEvent` triggers a `TransactionReversedEvent`, which Account Service listens to in order to release reserved funds.
+Compensation (rollback) is also event-driven: a `FraudSuspectedEvent` triggers a `TransactionReversalEvent`, which Wallet Service listens to in order to release reserved funds.
 
 ## Consequences
 

--- a/docs/adr/ADR-002-eventually-consistent-authorization.md
+++ b/docs/adr/ADR-002-eventually-consistent-authorization.md
@@ -17,21 +17,26 @@ Each service embeds a **local Policy Agent** — a lightweight in-process compon
 - **PIP (AttributeRepository):** Fetches and caches subject/resource/environment attributes.
 - **Local policy store:** An in-memory copy of compiled policies, kept fresh via Kafka.
 
-**Identity Service** is the single source of truth (PAP). It compiles YAML policy definitions at startup and distributes them via Kafka (`policy-updates` topic). It also publishes attribute change events (`attribute-changes` topic) when user or account state changes.
+**Identity Service** is the single source of truth (PAP). It compiles YAML policy definitions at startup and distributes them via Kafka (`policy-updates` topic). It also publishes specific domain attribute events when user or account state changes — `UserStatusChangedEvent`, `AccountStatusChangedEvent`, `KycLevelUpdatedEvent`, `MfaEnabledEvent` — consumed by each service's Policy Agent to update its local attribute cache.
 
 Each Policy Agent consumes these events and updates its local state. This makes authorization **eventually consistent**: there is a brief window after a policy or attribute change during which a service may still use the previous value. This is accepted as a deliberate trade-off.
 
-**Exception — revocation:** Access revocation is treated as a special case (see ADR-006). `AccessRevokedEvent` flows through a dedicated high-priority topic and triggers immediate cache invalidation.
+**Exception — revocation:** Access revocation is treated as a special case (see ADR-010). `AccessRevokedEvent` flows through a dedicated high-priority topic and triggers immediate cache invalidation.
 
 ## Consequences
 
 **Benefits:**
 - Zero network calls on the authorization hot path — decisions are made in-process.
 - No single point of failure for authorization.
-- Each service can extend its local PIP with domain-specific attributes (e.g., Account Service knows account balance and status).
+- Each service can extend its local PIP with domain-specific attributes (e.g., Wallet Service knows wallet balance and status).
 
 **Trade-offs:**
 - Policy updates are not instantaneous across services — eventual consistency window exists.
 - Each service carries the operational overhead of consuming and applying policy/attribute events.
 - Debugging authorization failures may require checking which policy version a specific service instance has loaded.
-- Full-sync events (`full-sync` topic) must be implemented to handle cold starts and drift recovery.
+
+## Cold Start and Drift Recovery
+
+On startup, each service consumes a `FullSyncEvent` from the `full-sync` Kafka topic. This event contains all current user attributes published by Identity Service and is used to warm the Policy Agent's attribute cache before the service begins accepting requests.
+
+If Kafka is unavailable on startup, the service falls back to L2 Redis cache (see ADR-005). Redis holds the last known attribute state with a longer TTL specifically to cover restart scenarios. If both Kafka and Redis are unavailable, the service starts with an empty attribute cache and builds it incrementally as domain events arrive — accepting the risk of briefly evaluating decisions with incomplete attributes.

--- a/docs/adr/ADR-005-two-level-cache.md
+++ b/docs/adr/ADR-005-two-level-cache.md
@@ -25,8 +25,8 @@ Implement a **two-level cache strategy** in every service's Policy Agent:
 
 **Cache invalidation:**
 - Policy updates: `PolicyUpdatedEvent` from Kafka invalidates both L1 and L2 for the affected policy.
-- Attribute changes: `AttributeChangedEvent` invalidates both levels for the affected subject or resource.
-- Access revocation: `AccessRevokedEvent` (see ADR-006) triggers immediate invalidation of both levels, bypassing TTL.
+- Attribute changes: specific domain events (`UserStatusChangedEvent`, `AccountStatusChangedEvent`, `KycLevelUpdatedEvent`, `MfaEnabledEvent`) invalidate both levels for the affected subject or resource.
+- Access revocation: `AccessRevokedEvent` (see ADR-010) triggers immediate invalidation of both levels, bypassing TTL.
 
 ## Consequences
 

--- a/docs/adr/ADR-007-uuid-v7-strategy.md
+++ b/docs/adr/ADR-007-uuid-v7-strategy.md
@@ -39,15 +39,14 @@ When Java 24+ is adopted, migration requires updating each factory method indivi
 ```java
 // Direct usage inside domain factory methods
 // Example: User.create() in identity-service
-public static User create(String username, String email, String passwordHash) {
-    Email userEmail = new Email(email);
-    Username userUsername = new Username(username);
+// Value Objects are constructed by the caller (handler), not inside the factory.
+public static User create(Username username, Email email, String passwordHash) {
     Instant now = Instant.now();
 
     return new User(
         Generators.timeBasedEpochGenerator().generate(),
-        userUsername,
-        userEmail,
+        username,
+        email,
         passwordHash,
         UserRole.USER_ROLE,
         KycLevel.KYC_LEVEL_1,
@@ -58,6 +57,11 @@ public static User create(String username, String email, String passwordHash) {
         now
     );
 }
+
+// Caller (RegisterUserHandler) constructs Value Objects before calling the factory:
+// Email email = new Email(command.email());
+// Username username = new Username(command.username());
+// User user = User.create(username, email, passwordEncoder.encode(command.password()));
 ```
 
 ## Migration Path

--- a/docs/adr/ADR-008-domain-model-user-account-wallet-balance.md
+++ b/docs/adr/ADR-008-domain-model-user-account-wallet-balance.md
@@ -25,8 +25,13 @@ OwnerType (USER, AGENT, MERCHANT) is deferred — MVP only supports USER.
 ## MVP Constraints
 - One User has one Account
 - One Account has one Wallet (BRL)
-- Account + Wallet created automatically on User registration
+- Account created synchronously during User registration by Identity Service
+- Wallet created asynchronously by Wallet Service upon consuming `AccountCreatedEvent` — not in the registration handler
 - Single asset: BRL
+
+## Implementation Notes
+
+**`Account.ownerId` field naming:** The Account entity references its owner via `ownerId` (not `userId`). This naming is intentional — it remains forward-compatible with the deferred `OwnerType` (USER, AGENT, MERCHANT). In MVP only USER is supported, but renaming the field later would require a schema migration and API change. All port methods (`findByOwnerId`, `existsByOwnerId`) follow the same convention.
 
 ## Consequences
 

--- a/docs/adr/ADR-009-cqrs-identity-service.md
+++ b/docs/adr/ADR-009-cqrs-identity-service.md
@@ -1,23 +1,26 @@
-# ADR-009: CQRS Strategy for Identity Service
+# ADR-009: CQS (Command Query Separation) for Identity Service
 
 ## Status
 Accepted
 
 ## Context
-The Identity Service handles two distinct types of operations: commands that modify state (RegisterUser, BlockUser, PromoteKyc) and queries that read state (GetUserProfile, GetAccountStatus). 
+The Identity Service handles two distinct types of operations: commands that modify state (RegisterUser, BlockUser, PromoteKyc) and queries that read state (GetUserProfile, GetAccountStatus).
 
-A decision was needed on whether to apply CQRS and at what level — basic semantic separation vs advanced read/write model separation with dedicated databases.
+A decision was needed on whether to apply command/query separation and at what level — basic semantic separation vs advanced read/write model separation with dedicated databases.
 
 Additionally, the proliferation of Command Handlers would create controllers with many injected dependencies, requiring a dispatch mechanism.
 
 ## Decision
 
-### CQRS Basic — applied to Identity Service
+### CQS (Command Query Separation) — applied to Identity Service
+
+This is CQS, not CQRS. CQRS (Command Query Responsibility Segregation) implies physically separate read and write models, typically with different databases or projections. CQS here means Commands and Queries are handled by separate classes via Mediator, but both use the same PostgreSQL database.
+
 Separate Commands (write operations) from Queries (read operations) at the structural and semantic level only. Both use the same PostgreSQL database. No separate read model or projections.
 
 Rationale: The Identity Service has balanced and simple read/write patterns. No read performance bottleneck justifies a separate read model. The value here is semantic clarity and learning the pattern in a simpler context before applying it fully in Transaction Service.
 
-### CQRS Advanced — reserved for Transaction Service
+### CQRS — reserved for Transaction Service
 Event Sourcing in Transaction Service requires genuine read/write separation: the write side appends events to an EventStore, the read side serves projections. CQRS is a necessity there, not a choice.
 
 ### Mediator Pattern
@@ -32,47 +35,65 @@ public interface Mediator {
 ```
 
 ### Application Layer Structure
+```
 application/
 ├── command/
-│   ├── user/
-│   │   ├── register/
-│   │   │   ├── RegisterUserCommand.java
-│   │   │   └── RegisterUserHandler.java
-│   │   └── .../
-│   └── account/
-│       └── .../
+│   └── user/
+│       ├── authenticate/
+│       │   ├── login/
+│       │   └── register/
+│       ├── admin/
+│       │   ├── kyc/
+│       │   ├── promote/
+│       │   └── revoke/
+│       ├── mfa/
+│       │   ├── confirm/
+│       │   ├── disable/
+│       │   └── setup/
+│       └── status/
+│           ├── activate/
+│           ├── block/
+│           └── suspend/
 ├── query/
 │   ├── user/
-│   │   └── getuserprofile/
-│   │       ├── GetUserProfileQuery.java
-│   │       └── GetUserProfileHandler.java
+│   │   ├── profile/
+│   │   └── byemail/
 │   └── account/
-│       └── .../
-├── eventhandler/
-│   └── FraudSuspectedEventHandler.java
+│       ├── status/
+│       └── byownerid/
 ├── mediator/
 │   ├── Mediator.java
+│   ├── Command.java
 │   ├── CommandHandler.java
+│   ├── Query.java
 │   └── QueryHandler.java
 └── port/out/
-├── UserRepositoryPort.java
-├── AccountRepositoryPort.java
-└── EventPublisherPort.java
+    ├── EventPublisherPort.java
+    ├── PasswordEncoderPort.java
+    ├── TokenGeneratorPort.java
+    ├── TotpGeneratorPort.java
+    ├── TotpValidatorPort.java
+    └── MfaSetupCachePort.java
+```
 
-*Implementation of Mediator should be on Infrastructure*
+Account Commands are deferred — Account state changes are driven by User status commands that cascade internally within the same handler. There is no standalone `command/account/` package.
+
+Event Handlers for external Kafka events (from other services) belong in the infrastructure layer, not in the application layer. The application layer only defines commands, queries, and output ports.
+
+*Implementation of Mediator lives in infrastructure (`infrastructure/mediator/MediatorImpl`).*
 
 ## Consequences
 
 **Gains:**
 - Semantic clarity — commands and queries are explicitly separated
 - Controllers depend only on Mediator — thin and testable
-- Learning CQRS in a simpler context before Transaction Service
+- Learning CQS before full CQRS in Transaction Service
 - Adding new commands/queries requires no changes to existing code — open/closed
 
 **Costs:**
 - More classes per operation — Command + Handler per use case
 - Mediator adds indirection — harder to trace execution flow at first glance
-- CQRS basic does not solve read performance — same database for reads and writes
+- CQS does not solve read performance — same database for reads and writes
 
 ## What this is NOT
 - CQRS with separate read/write databases in Identity Service

--- a/docs/adr/ADR-013-abac-policy-distribution-strategy.md
+++ b/docs/adr/ADR-013-abac-policy-distribution-strategy.md
@@ -1,0 +1,50 @@
+# ADR-013: ABAC Policy Distribution Strategy
+
+## Status
+Accepted
+
+## Context
+The initial ABAC design (ADR-002, ADR-003) described Identity Service compiling YAML policies at startup and distributing them to all services via Kafka (`policy-updates` topic). Each service's Policy Agent would maintain an in-memory policy store kept fresh by consuming these events.
+
+This model introduces a critical startup dependency: if Identity Service is unavailable, no service can load its policies and therefore cannot evaluate any authorization decision. This contradicts the Choreography Saga principle of service autonomy (ADR-001) and the goal of removing single points of failure from the authorization hot path (ADR-002).
+
+Two distribution models were evaluated:
+
+1. **Kafka-distributed policies:** Identity Service is the single source of truth; policies flow via events at runtime.
+2. **Embedded policies:** Each service owns its YAML policy files in its own resources; loads them independently at startup.
+
+## Decision
+Policies are **embedded in each service** as YAML files under the service's own `resources/policies/` directory. Each service loads and compiles its own policies at startup independently, with no dependency on Identity Service or Kafka.
+
+Identity Service distributes only **dynamic user and account attributes** via Kafka — not policy rules:
+- `UserStatusChangedEvent`
+- `AccountStatusChangedEvent`
+- `KycLevelUpdatedEvent`
+- `MfaEnabledEvent`
+- `AccessRevokedEvent` (high-priority topic)
+- `FullSyncEvent` (startup warm-up, see ADR-002)
+
+This creates a clear separation between two categories:
+
+| Category | Owner | Change mechanism |
+|---|---|---|
+| Policy rules (static) | Each service (embedded YAML) | Redeploy of that service |
+| User/account attributes (dynamic) | Identity Service (Kafka events) | Runtime, eventually consistent |
+
+The `policy-updates` Kafka topic described in ADR-002 and ADR-003 is **not implemented**. Policy changes require a service redeploy.
+
+## Consequences
+
+**Gains:**
+- Zero startup coupling between services and Identity Service — each service boots independently regardless of IAM availability.
+- Each service is truly autonomous in its authorization path.
+- Identity Service failure does not affect policy evaluation in other services.
+- Simpler Policy Agent implementation — no Kafka consumer needed for policy loading.
+
+**Costs:**
+- Policy rule changes require a redeploy of every affected service, not a single Kafka publish.
+- No central policy management UI in MVP — policy review requires reading YAML files in each service's repository.
+- Future migration to centralized policy management (OPA, AWS AppConfig) will require extracting policies from each service JAR.
+
+## Future
+If centralized policy management without redeploy coupling is needed, OPA or AWS AppConfig are natural candidates. The embedded YAML DSL (ADR-003) is designed to be portable — migrating means moving the YAML files and pointing the compiler at the new source, not redesigning the DSL.

--- a/docs/adr/ADR-014-hexagonal-architecture-ports-adapters.md
+++ b/docs/adr/ADR-014-hexagonal-architecture-ports-adapters.md
@@ -1,0 +1,67 @@
+# ADR-014: Hexagonal Architecture — Ports and Adapters
+
+## Status
+Accepted
+
+## Context
+The Identity Service needed a clear structural boundary between business logic and infrastructure concerns. Without an explicit boundary, Spring annotations, JPA entities, and Kafka dependencies tend to leak into domain and application logic over time — making unit tests slow (requiring a Spring context), making the domain hard to reason about in isolation, and creating tight coupling to specific frameworks.
+
+Two structural approaches were evaluated:
+
+1. **Layered Architecture (traditional):** Presentation → Service → Repository. Simple, familiar, but typically results in service classes that depend directly on JPA repositories, making domain logic inseparable from persistence.
+2. **Hexagonal Architecture (Ports and Adapters):** Business logic at the center defines interfaces (ports); infrastructure provides implementations (adapters). Dependencies point inward — never outward.
+
+## Decision
+Adopt **Hexagonal Architecture** with three explicit layers:
+
+### Domain Layer (`domain/`)
+Pure Java — no framework dependencies, no Spring annotations, no JPA, no Kafka.
+
+Contains:
+- **Entities:** `User`, `Account` — rich domain objects with behavior, not anemic data holders.
+- **Value Objects:** `Email`, `Username`, `UserStatus`, `AccountStatus`, `KycLevel` — immutable, self-validating.
+- **Domain Events:** `DomainEvent` interface + all concrete events (`UserRegisteredEvent`, `AccountCreatedEvent`, etc.).
+- **Domain Exceptions:** invariant violations (`InvalidStatusTransitionException`, `MfaAlreadyEnabledException`, etc.).
+- **Repository Ports:** `UserRepositoryPort`, `AccountRepositoryPort` — interfaces defined by the domain, implemented by infrastructure.
+
+### Application Layer (`application/`)
+Orchestration only — no framework dependencies. Depends on domain, but not on infrastructure.
+
+Contains:
+- **Command Handlers:** write use cases (`RegisterUserHandler`, `BlockUserHandler`, etc.).
+- **Query Handlers:** read use cases (`GetUserProfileHandler`, `GetAccountStatusHandler`, etc.).
+- **Mediator interfaces:** `Mediator`, `CommandHandler`, `QueryHandler`.
+- **Output Ports:** interfaces for non-domain infrastructure concerns that handlers need — `EventPublisherPort`, `PasswordEncoderPort`, `TokenGeneratorPort`, `TotpGeneratorPort`, `TotpValidatorPort`, `MfaSetupCachePort`.
+- **Application Exceptions:** use case failures (`UserNotFoundException`, `DuplicateEmailException`, `InvalidCredentialsException`, etc.).
+- **DTOs:** `TokenClaims`, `TokenPair`.
+
+### Infrastructure Layer (`infrastructure/`)
+All framework dependencies live here. Implements the ports defined in domain and application layers.
+
+Contains:
+- **Persistence adapters:** JPA entities, Spring Data repositories, port implementations.
+- **Messaging adapters:** Kafka publisher implementing `EventPublisherPort`; Kafka consumers for ABAC attribute events.
+- **Security adapters:** BCrypt implementing `PasswordEncoderPort`; JWT implementing `TokenGeneratorPort`; TOTP library adapters.
+- **Cache adapters:** Redis implementing `MfaSetupCachePort` and Policy Agent L2 cache.
+- **Mediator implementation:** `MediatorImpl` — Spring `@Component`, wires all handlers at startup.
+- **Policy Agent:** ABAC evaluation, embedded YAML policy loading, PDP/PIP.
+- **Web adapters:** Spring MVC controllers, `GlobalExceptionHandler`.
+
+### Dependency Rule
+```
+Infrastructure → Application → Domain
+```
+This direction is strictly enforced. Domain never imports from application or infrastructure. Application never imports from infrastructure.
+
+## Consequences
+
+**Gains:**
+- Domain layer is testable in pure JUnit without loading a Spring context — entities and value objects are plain Java.
+- Infrastructure can be swapped without touching domain or application logic (e.g., replacing PostgreSQL with another store requires only a new persistence adapter).
+- Clear boundaries prevent coupling creep — a PR that adds a Spring annotation to a domain class is immediately visible as a violation.
+- Forces explicit modeling of what is "business logic" vs "technical concern."
+
+**Costs:**
+- More classes per feature — domain entity, JPA entity, and mapping between them.
+- Developers must know which layer owns each class. Violations are easy to make and require discipline to prevent.
+- Output ports in the application layer add one level of indirection for infrastructure concerns that are straightforward in a layered architecture.

--- a/docs/adr/ADR-015-exception-hierarchy-domain-vs-application.md
+++ b/docs/adr/ADR-015-exception-hierarchy-domain-vs-application.md
@@ -1,0 +1,60 @@
+# ADR-015: Exception Hierarchy — Domain vs Application
+
+## Status
+Accepted
+
+## Context
+Exceptions needed clear ownership to prevent infrastructure concerns (HTTP status codes, Spring annotations) from leaking into the domain, and to prevent domain invariant violations from being confused with use case orchestration failures.
+
+Without a defined rule, developers tend to put exceptions wherever is convenient — leading to domain classes that import `org.springframework.http.HttpStatus`, or application handlers catching `IllegalArgumentException` from deep inside a value object constructor.
+
+## Decision
+Two separate exception hierarchies, one per layer:
+
+### Domain Exceptions (`domain/exception/`)
+Represent **invariant violations** — states that should never be reachable if the system is used correctly. Thrown by entities and value objects when their internal rules are broken.
+
+Pure Java. Zero framework dependencies.
+
+Examples:
+- `InvalidUserStatusTransitionException` — thrown by `UserStatus` when an illegal state transition is attempted.
+- `InvalidAccountStatusTransitionException` — thrown by `AccountStatus`.
+- `InvalidKycPromotionException` — thrown by `KycLevel` when a promotion skips a level.
+- `InvalidRolePromotionException` / `InvalidRoleRevokeException` — thrown by `User` when role logic is violated.
+- `MfaAlreadyEnabledException` / `MfaNotEnabledException` — thrown by `User` when MFA state is inconsistent.
+- `InvalidEmailException` / `InvalidUsernameException` / `InvalidPasswordException` — thrown by Value Object constructors on malformed input.
+
+### Application Exceptions (`application/exception/`)
+Represent **use case failures** — conditions that are expected during normal system operation, raised by handlers when orchestration constraints are violated.
+
+Three base classes express the category:
+- `ResourceNotFoundException` — requested entity does not exist.
+- `ResourceAlreadyExistsException` — attempted creation of a duplicate entity.
+- `AuthenticationException` — identity or credential verification failed.
+
+Concrete exceptions extend these bases:
+- `UserNotFoundException`, `AccountNotFoundException` → `ResourceNotFoundException`
+- `DuplicateEmailException`, `DuplicateUsernameException` → `ResourceAlreadyExistsException`
+- `InvalidCredentialsException`, `MfaRequiredException`, `InvalidMfaCodeException`, `MfaSetupExpiredException`, `UserInactiveException` → `AuthenticationException`
+
+### HTTP Mapping
+HTTP status codes are assigned exclusively in `GlobalExceptionHandler` in the infrastructure layer. No exception in the domain or application layer carries or references an HTTP status code. The mapping rule is:
+
+| Base class | HTTP status |
+|---|---|
+| `ResourceNotFoundException` | 404 Not Found |
+| `ResourceAlreadyExistsException` | 409 Conflict |
+| `AuthenticationException` | 401 Unauthorized |
+| Domain exceptions (uncaught) | 500 Internal Server Error |
+
+## Consequences
+
+**Gains:**
+- Domain exceptions express business language — a reader understands what went wrong from the class name alone.
+- Application exceptions express orchestration failures — the caller knows whether to retry, redirect, or report.
+- HTTP concerns are isolated to one class in infrastructure — changing a status code requires changing one place.
+- Domain layer has zero dependency on any web framework.
+
+**Costs:**
+- Two exception packages to navigate. Developers must decide which layer owns a new exception before writing it.
+- Domain exceptions that escape to the HTTP boundary unhandled will produce a 500 — requires discipline to ensure all domain exceptions that can reach the web layer are either caught in handlers or mapped in `GlobalExceptionHandler`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,3 +10,10 @@ This directory contains all ADRs for the Ciphernance project. Each ADR documents
 | [ADR-004](ADR-004-event-sourcing-transaction-service.md) | Event Sourcing scoped to Transaction Service | Accepted |
 | [ADR-005](ADR-005-two-level-cache.md) | Two-level cache (L1 Caffeine + L2 Redis) for Policy Agents | Accepted |
 | [ADR-006](ADR-006-no-decision-cache-financial.md) | No decision-level cache in financial authorization | Accepted |
+| [ADR-007](ADR-007-uuid-v7-strategy.md) | UUID v7 as Primary Key Strategy | Accepted |
+| [ADR-008](ADR-008-domain-model-user-account-wallet-balance.md) | Domain Model — User, Account, Wallet, Balance | Accepted |
+| [ADR-009](ADR-009-cqrs-identity-service.md) | CQS (Command Query Separation) for Identity Service | Accepted |
+| [ADR-010](ADR-010-jwt-blocklist-redis.md) | JWT Session Invalidation via Redis Blocklist | Accepted |
+| [ADR-013](ADR-013-abac-policy-distribution-strategy.md) | ABAC Policy Distribution Strategy | Accepted |
+| [ADR-014](ADR-014-hexagonal-architecture-ports-adapters.md) | Hexagonal Architecture — Ports and Adapters | Accepted |
+| [ADR-015](ADR-015-exception-hierarchy-domain-vs-application.md) | Exception Hierarchy — Domain vs Application | Accepted |

--- a/services/identity-service/README.md
+++ b/services/identity-service/README.md
@@ -1,0 +1,85 @@
+# Identity Service
+
+The Identity Service is the IAM (Identity and Access Management) core of Ciphernance. It is the source of truth for user identities, account anchors, and dynamic ABAC attributes.
+
+## Responsibilities
+
+- User registration and authentication (JWT-based)
+- Account identity anchor management (not financial state)
+- KYC level management
+- MFA setup and validation (TOTP)
+- ABAC attribute distribution via Kafka events
+- Policy evaluation for its own endpoints
+
+## What this service does NOT own
+
+- Wallet state or balances (owned by Wallet Service)
+- Transaction processing (owned by Transaction Service)
+- Fraud analysis (owned by Fraud Service)
+- ABAC policy rules of other services (each service owns its own policies)
+
+## Architecture
+
+Hexagonal Architecture (Ports and Adapters) with CQS via Mediator Pattern.
+See [ADR-009](../../docs/adr/ADR-009-cqrs-identity-service.md) and [ADR-014](../../docs/adr/ADR-014-hexagonal-architecture-ports-adapters.md) for details.
+
+## Domain Model
+
+```
+User (1) → Account (1:1 in MVP, 1:N in future)
+```
+
+Account is an identity anchor only — no financial data. Financial state lives in Wallet Service.
+
+## Tech Stack
+
+| Layer | Technology |
+|---|---|
+| Language | Java 21 |
+| Framework | Spring Boot 4 |
+| Database | PostgreSQL 17 (via Flyway migrations) |
+| Cache | Redis (MFA setup cache + ABAC attribute cache L2) |
+| Messaging | Kafka (publishes domain events) |
+| Security | Spring Security + JWT (manual, not Spring Authorization Server) |
+| Build | Maven |
+
+## Package Structure
+
+```
+io.ciphernance.identity/
+├── domain/                  ← pure Java, no framework dependencies
+│   ├── model/               ← User, Account
+│   ├── vo/                  ← Email, Username, KycLevel, UserStatus, AccountStatus
+│   ├── event/               ← DomainEvent interface + all domain events
+│   ├── exception/           ← domain invariant violations
+│   └── port/                ← UserRepositoryPort, AccountRepositoryPort
+├── application/             ← orchestration only
+│   ├── command/             ← Commands + Handlers (write operations)
+│   ├── query/               ← Queries + Handlers (read operations)
+│   ├── mediator/            ← Mediator interface, Command/QueryHandler interfaces
+│   ├── port/out/            ← EventPublisherPort, TokenGeneratorPort, etc.
+│   └── exception/           ← application-level exceptions
+└── infrastructure/          ← all framework dependencies
+    ├── persistence/         ← JPA entities, repositories, adapters
+    ├── messaging/           ← Kafka publisher and consumers
+    ├── security/            ← JWT, BCrypt, TOTP adapters
+    ├── mediator/            ← MediatorImpl
+    ├── policy/              ← Policy Agent, ABAC evaluation
+    └── web/                 ← Controllers, GlobalExceptionHandler
+```
+
+## Running locally
+
+Requires Docker Compose infrastructure running:
+
+```bash
+cd infrastructure
+docker compose up -d
+```
+
+Then run the service:
+
+```bash
+cd services/identity-service
+mvn spring-boot:run
+```


### PR DESCRIPTION
## Summary
Fixes all inconsistencies identified in the ADR review and adds three new ADRs 
documenting decisions made during implementation.

## Fixes

### Contradictions resolved
- ADR-001: Account Service → Wallet Service throughout
- ADR-002: AttributeChangedEvent removed — replaced by specific domain events
- ADR-005: Cross-reference ADR-006 → ADR-010 corrected
- ADR-009: CQRS Basic renamed to CQS with explanation of the distinction

### Outdated content updated
- ADR-007: User.create() signature corrected
- ADR-008: Async Wallet creation via AccountCreatedEvent clarified, ownerId rationale added
- ADR-009: Package structure updated — command/account/ and eventhandler/ removed

### Missing context added
- ADR-002: Full-sync mechanism documented
- ADR-008: Wallet creation flow clarified

## New ADRs
- ADR-013: ABAC policy distribution — policies embedded per service, 
  IAM distributes only dynamic attributes via Kafka
- ADR-014: Hexagonal Architecture — three layers, dependency rule, what lives where
- ADR-015: Exception hierarchy — domain invariants vs application exceptions, 
  HTTP mapping isolated to GlobalExceptionHandler

## Documentation
- docs/adr/README.md: all 13 ADRs listed
- README.md: ADR table expanded, application layer marked as done
- services/identity-service/README.md: created

## Checklist
- [x] No contradictions between ADRs
- [x] All decisions made during implementation are documented
- [x] README reflects current state of the project
- [x] Identity Service has its own README